### PR TITLE
remove .vscode directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "C:\\Users\\Kush Rawal\\.virtualenvs\\DS-dVg1tSqQ\\Scripts\\python.exe"
-}


### PR DESCRIPTION
This pull request removes the .vscode directory from the project.

The .vscode directory contains settings individual to each team member. After removing from the repo, each team member's .vscode directory should be ignored based on the .gitignore file.
